### PR TITLE
Docstring fixes and infinite redirects

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -1270,16 +1270,23 @@ URL-MAPPING-TABLE is an alist of:
 
 To map the root url you should use:
 
-  $
+  \"^$\"
 
-'elnode-dispatcher' uses 'elnode-normalize-path' to ensure paths
-end in / so to map another url you should use:
+To ensure paths end in /, `elnode-dispatcher' uses
+`elnode-normalize-path'.  To map another url you should use:
 
-  path/$
+  \"^path/$\" or \"^path/sub-path/$\"
 
-or:
+An example server setup:
 
-  path/sub-path/$"
+  (defun my-server (httpcon)
+    (elnode-dispatcher
+     httpcon
+     '((\"^$\" . root-view)
+       (\"^1/$\" . view-1))))
+
+If FUNCTION-404 is non-nil then it is called when no regexp is
+matched."
   (elnode-normalize-path
    httpcon
    (lambda (httpcon)


### PR DESCRIPTION
What's up Nic,

I updated a bunch of the docstring to use some additional elisp conventions, namely surrounding functions with tex style single quotes (`text') so they get hyperlinked in the docs.

I found two bugs.  The first is in `elnode-normalize-path` to add slashes to all urls not ending in an extension.  I added a not clause to the if statement to switch the logic and prevent infinite redirects that add a trailing slash each time.

The second is the in `elnode--mapper-find`.  The loop macro used `finally return` and would return the last mapping regardless of whether it matched or not.  Also, you need to use `^` in all regexps to prevent partial matches, especially when matching the root. `$` matches all strings.  To match just the root you must use `^$`.
