### PR TITLE
small bug fix

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -1429,7 +1429,7 @@ matched."
         httpcon
         pathinfo
         url-mapping-table
-        function-404)))))
+        :function-404 function-404)))))
 
 (defun* elnode-hostpath-dispatcher (httpcon
                                    hostpath-mapping-table


### PR DESCRIPTION
- elnode.el (elnode-dispatcher): The `elnode--dispatch-proc' function
  expects a keyword argument so we better give it one.

It looks like most dev. has moved to the auth branch, should we follow that branch instead of master?
