### PR TITLE
elnode-webserver-extra-mimetypes not in use by elnode-make-webserver ?

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -2955,7 +2955,10 @@ handlers."
                 (elnode-http-start httpcon 200 '("Content-type" . "text/html"))
                 (elnode-http-return httpcon index))))
         ;; Send a file.
-        (elnode-send-file httpcon targetfile)))))
+        (elnode-send-file
+         httpcon
+         targetfile
+         :mime-types mime-types)))))
 
 (defun elnode-webserver-handler-maker (&optional docroot extra-mime-types)
   "Make a webserver handler possibly with the DOCROOT and EXTRA-MIME-TYPES.


### PR DESCRIPTION
When I add ("application/javascript" . "js") to elnode-webserver-extra-mimetypes, I still don't get served the right mimetype from my elnode-make-webserver ... any ideas?
