### PR TITLE
Addition of Last-Modified header to elnode-send-file to get caching to work in browsers

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -2726,7 +2726,8 @@ delivered."
                   "application/octet-stream")))
 	(elnode-http-start httpcon 200 
 			   `("Content-type" . ,mimetype)
-			   `("Last-Modified" . ,(elnode--file-modified-time targetfile)))
+			   `("Last-Modified" . ,(elnode--rfc1123-date 
+						 (elnode--file-modified-time targetfile))))
         (when preamble (elnode-http-send-string httpcon preamble))
         (if (or elnode-webserver-visit-file replacements)
             (let ((file-buf (find-file-noselect filename)))


### PR DESCRIPTION
Hi Nic,

Thanks for the help with the caching a couple of nights ago! I decided to take your "challenge" (which it is for me) and create a pull request for you. Git is very new to me so forgive me if I am not doing this the right way. Anyway, I forked your elnode project, cloned that to my PC, and pushed the changes back to my Github account. Seems like that has worked. So now, the last step, a pull request for you :)

About the change:

It was quite messy to create a timestamp on the right format since `format-time-string` in Emacs cannot produce un-localized day and month names. Hence the new function. Also, since you already used `file-attributes` in another place to get the modification time, I decided to break that out into a new function as well.

Enjoy!

/Mathias
