### PR TITLE
changed regex in elnode--http-parse-status to support arbitrary methods

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -645,7 +645,7 @@ available.")
     (if (equal
 	 (process-buffer
 	  ;; Get the server process
-	  (cdr (assoc 
+	  (cdr (assoc
 		(process-contact process :service)
 		elnode-server-socket)))
 	 (process-buffer process))
@@ -659,7 +659,7 @@ available.")
     (when (process-buffer process)
       (kill-buffer (process-buffer process))
       (elnode-error "Elnode connection dropped %s" process)))
-   
+
    ((equal status "open\n") ;; this says "open from ..."
     (elnode-error "Elnode opened new connection"))
 
@@ -1486,10 +1486,14 @@ cons is returned."
   "Parse the status line of HTTPCON.
 
 If PROPERTY is non-nil, then return that property."
-  (let ((http-line (process-get httpcon :elnode-http-status)))
-    (string-match
-     "\\([A-Z]+\\) \\(.*\\) HTTP/\\(1.[01]\\)"
-     http-line)
+  (let* ((http-line (process-get httpcon :elnode-http-status))
+         (method-regex (mapconcat
+                        'identity
+                        (list "GET" "POST" "HEAD" "DELETE" "PUT")
+                        "\\|")))
+    (string-match (format "\\(%s\\) \\(.*\\) HTTP/\\(1.[01]\\)"
+                          method-regex)
+                  http-line)
     (process-put httpcon :elnode-http-method (match-string 1 http-line))
     (process-put httpcon :elnode-http-resource (match-string 2 http-line))
     (process-put httpcon :elnode-http-version (match-string 3 http-line))
@@ -2782,7 +2786,7 @@ It should not be used otherwise.")
 	 (day (nth (nth 6 decoded-time) day-names))
 	 (month (nth (- (nth 4 decoded-time) 1) month-names)))
     (format "%s, %s %s %s"
-	    day 
+	    day
 	    (format-time-string "%m" time t)
 	    month
 	    (format-time-string "%Y %H:%M:%S GMT" time t))))


### PR DESCRIPTION
I'm not sure how servers are supposed to handle non-standard methods. I'd think passing them to the application would be better, at least from the forward-compatibility point of view. An alternative would be to extend the regex to handle all standard methods.

Btw, I had an issue with elnode, where emacs would send a blank response, and not use the handler. Maybe once every 70 requests. I'm not even sure whether it gets to the filter stage. Is this a known problem?
