### PR TITLE
fix Last-Modified header

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -2893,7 +2893,7 @@ It should not be used otherwise.")
 	 (month (nth (- (nth 4 decoded-time) 1) month-names)))
     (format "%s, %s %s %s"
 	    day
-	    (format-time-string "%m" time t)
+	    (format-time-string "%d" time t)
 	    month
 	    (format-time-string "%Y %H:%M:%S GMT" time t))))
 


### PR DESCRIPTION
elnode--rfc1123-date was incorrectly sending the month number as day
number, which leads to incorrect caching in browsers.

The defect went as such:

(elnode--rfc1123-date (list 20986 3923 0 0)) Thu, 08 Aug 2013 07:33:39 GMT

(format-time-string "%Y-%m-%dT%T%z" (list 20986 3923 0 0) 2013-08-01T09:33:39+0200
