### PR TITLE
Quote eval-after-load form

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -4001,7 +4001,7 @@ init.")
 ;; Auto start elnode if we're ever loaded
 ;;;###autoload
 (eval-after-load 'elnode
-  (if (and (boundp 'elnode-do-init)
+  '(if (and (boundp 'elnode-do-init)
            elnode-do-init
 	   (or (not (boundp 'elnode--inited))
 	       (not elnode--inited)))


### PR DESCRIPTION
`eval-after-load` is no macro, so its body form must be quoted.
