### PR TITLE
do not start a server when required or loaded

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -3955,11 +3955,7 @@ SCHEME is the authentication scheme to use as defined by
 
 ;;;###autoload
 (defun elnode-init ()
-  "Bootstraps the elnode environment when the Lisp is loaded.
-
-It's useful to have elnode start automatically... on Lisp
-load.  If the variable `elnode-init-port' is set then this
-function will launch a server on it.
+  "Bootstraps the elnode environment and start the default server.
 
 The server is started with `elnode-hostpath-default-handler' as
 the handler and listening on `elnode-init-host'"
@@ -3978,36 +3974,6 @@ the handler and listening on `elnode-init-host'"
   (if elnode-defer-on
       (if (not elnode--defer-timer)
           (elnode--init-deferring))))
-
-(defcustom elnode-do-init 't
-  "Should elnode start a server on load?
-
-The server that is started is controlled by more elnode
-customizations.
-
-`elnode-hostpath-default-table' defines the mappings from
-hostpath regexs to handler functions. By default elnode ships
-with this customization setup to serve the document root defined
-in `elnode-webserver-docroot', which by default is ~/public_html."
-  :group 'elnode
-  :type '(boolean))
-
-(defvar elnode--inited nil
-  "Records when elnode is initialized.
-
-This is autoloading mechanics, see the eval-after-load for doing
-init.")
-
-;; Auto start elnode if we're ever loaded
-;;;###autoload
-(eval-after-load 'elnode
-  (if (and (boundp 'elnode-do-init)
-           elnode-do-init
-	   (or (not (boundp 'elnode--inited))
-	       (not elnode--inited)))
-      (progn
-        (elnode-init)
-        (setq elnode--inited nil))))
 
 (provide 'elnode)
 


### PR DESCRIPTION
This commit removes elnode-do-init and the related initialization
machinery.  The elnode-do-init customization variable can not be set
until after elnode is loaded.  By this time the server has already been
started so setting the value of elnode-do-init has no effect.  Thus this
customization variable is useless and should be removed.

There are many valid uses of elnode which do _not_ require the default
server to be launched (e.g., running any non-default server, or
requiring elnode for development).  See issues #45 and #80.

This commit also updates the documentation of the elnode-init function.
