### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -330,7 +330,7 @@ correctly.
 Elnode also has {{{elnode-send-file}}} for sending files to the response,
 along with {{{elnode-docroot-for}}} this makes a powerful simple
 webserver tool.  {{{elnode-send-file}}} can be used to send any
-arbitary file:
+arbitrary file:
 
 {{{
 ##! emacs-lisp


### PR DESCRIPTION
@nicferrier, I've corrected a typographical error in the documentation of the [elnode](https://github.com/nicferrier/elnode) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
