### PR TITLE
Make Elnode work on Emacs 26.1

### DIFF
--- a/elnode.el
+++ b/elnode.el
@@ -1116,7 +1116,7 @@ is ignored."
            :name name
            :buffer an-buf
            :server (if (numberp port) 300 't)
-           :nowait 't
+           :nowait (< emacs-major-version 26)
            :host (cond
                    ((not (numberp port)) nil)
                    ((equal host "localhost") 'local)
@@ -1266,7 +1266,7 @@ The port is chosen randomly from the ephemeral ports. "
                     (make-network-process
                      :name "*test-proc*"
                      :server t
-                     :nowait 't
+                     :nowait (< emacs-major-version 26)
                      :host 'local
                      :service port
                      :family 'ipv4))


### PR DESCRIPTION
Elnode doesn't work on Emacs 26.1, because in `make-network-process`, `:nowait` and
`:server` can no longer be true simultaneously. Add a cautious fix for this, which flips `:nowait` to nil
on Emacs 26.1 upwards.

This fix should be safe. It's the [same method used by `emacs-web-server`](https://github.com/eschulte/emacs-web-server/commit/cafa5b7582c57252a0884b2c33da9b18fb678713) to fix the same bug. Digging around, Emacs 25 [ignores](http://emacs.1067599.n8.nabble.com/bug-31903-27-0-50-Server-sockets-with-nowait-no-longer-work-tp458589p459816.html) `:nowait` when server it `t`. Emacs 26.1 just formalises this, by throwing an error.

Fixes #106
Closes #105

Initially I thought Emacs 25.1+ was broken, but it looks like this isn't the case - it seems to be exclusive to Emacs 26.1+.